### PR TITLE
SSupport for devDependencies and proper bower dependencies filtering from package.json

### DIFF
--- a/wiredep-away.js
+++ b/wiredep-away.js
@@ -34,8 +34,17 @@ function wiredep(opts) {
 
   config.set
     ('bower.json', opts.bowerJson || getBowerConfig(cwd))
+  config.set('on-error', opts.onError || function(err) {
+      throw new Error(err);
+    })
+    ('on-file-updated', opts.onFileUpdated || function() {})
+    ('on-main-not-found', opts.onMainNotFound || function() {})
+    ('on-path-injected', opts.onPathInjected || function() {})
+    ('search-in-node-modules', opts.searchInNodeModules || opts.nodeModules || false);
+
+  config.set('bower.json', opts.bowerJson || getBowerConfig(cwd))
     ('bower-directory', opts.directory || findBowerDirectory(cwd))
-    ('nodemodules-directory', opts.nodeModules || $.path.resolve(cwd, './node_modules'))
+    ('nodemodules-directory', config.get('search-in-node-modules') ? (opts.nodeModules || $.path.resolve(cwd, './node_modules')) : config.get('bower-directory'))
     ('cwd', cwd)
     ('dependencies', opts.dependencies === false ? false : true)
     ('detectable-file-types', [])

--- a/wiredep-away.js
+++ b/wiredep-away.js
@@ -103,7 +103,8 @@ function getBowerConfig(cwd) {
 
   Object.keys(packageObj.dependencies)
     .map(function (dep) {
-      return dependencies[dep.replace('@bower_components/', '')] = packageObj.dependencies[dep];
+      if(dep.indexOf('@bower_components/') !== -1)
+      		return dependencies[dep.replace('@bower_components/', '')] = packageObj.dependencies[dep];
     });
 
   return {

--- a/wiredep-away.js
+++ b/wiredep-away.js
@@ -102,15 +102,25 @@ function getBowerConfig(cwd) {
   var dependencies = {};
 
   Object.keys(packageObj.dependencies)
-    .map(function (dep) {
-      if(dep.indexOf('@bower_components/') !== -1)
-      		return dependencies[dep.replace('@bower_components/', '')] = packageObj.dependencies[dep];
+    .forEach(function (dep) {
+      if (dep.indexOf('@bower_components/') !== -1) {
+        dependencies[dep.replace('@bower_components/', '')] = packageObj.dependencies[dep];
+      }
+    });
+
+  var devDependencies = {};
+  Object.keys(packageObj.devDependencies)
+    .forEach(function (dep) {
+      if (dep.indexOf('@bower_components/') !== -1) {
+        devDependencies[dep.replace('@bower_components/', '')] = packageObj.devDependencies[dep];
+      }
     });
 
   return {
     name: packageObj.name,
     version: packageObj.version,
-    dependencies: dependencies
+    dependencies: dependencies,
+    devDependencies: devDependencies
   };
 }
 


### PR DESCRIPTION
Hi there!

The devDependencies in package.json where ignored, moreover, the dependencies from package.json where not limited to @bower_components/**

This PR fixed both issues.

Btw. In your history, you had it similar like this patch, but then you decided to change it, could you please explain it?

Thank you!
